### PR TITLE
Use internal pyxform has_external_choices which is kept up-to-date

### DIFF
--- a/xlsform_app/templates/upload.html
+++ b/xlsform_app/templates/upload.html
@@ -58,6 +58,6 @@ $(document).ready(function() {
 
 <div id="output">
 </div>
-<div class="version muted">v1.2.0</div>
+<div class="version muted">v1.2.1</div>
 </body>
 </html> 

--- a/xlsform_app/views.py
+++ b/xlsform_app/views.py
@@ -11,7 +11,7 @@ import codecs
 
 import pyxform
 from pyxform import xls2json
-from pyxform.utils import sheet_to_csv
+from pyxform.utils import sheet_to_csv, has_external_choices
 
 DJANGO_TMP_HOME = os.environ['DJANGO_TMP_HOME']
 
@@ -55,23 +55,6 @@ def json_workbook(request):
                                        'error': error,
                                        'warnings': warningsList,
                                    }, indent=4), mimetype="application/json")
-
-
-def has_external_choices(json_struct):
-    """
-    Returns true if a select one external prompt is used in the survey.
-    """
-    if isinstance(json_struct, dict):
-        for k, v in json_struct.items():
-            if k == u"type" and v.startswith(u"select one external"):
-                return True
-            elif has_external_choices(v):
-                return True
-    elif isinstance(json_struct, list):
-        for v in json_struct:
-            if has_external_choices(v):
-                return True
-    return False
 
 @xframe_options_exempt
 def index(request):


### PR DESCRIPTION
Closes #12 

The difference between xlsform-online and xlsform-offline seemed to be the use of `has_external_choices`. The former uses it's own version and the latter uses pyxform's. 

xlsform-online: https://github.com/opendatakit/xlsform-online/blob/master/xlsform_app/views.py#L60
xlsform-offline: https://github.com/opendatakit/xlsform-offline/blob/master/src/worker.py#L17
pyxform: https://github.com/XLSForm/pyxform/blob/master/pyxform/xls2xform.py#L8

When I looked at `has_external_choices` in the pyxform source at I noticed that there is `and isinstance(v, basestring)` that is missing from xlsform-online. You can see that at https://github.com/XLSForm/pyxform/blob/1493706622c329fd2913ae691a902bca054250d4/pyxform/utils.py#L175.

I think the most sustainable solution is to use whatever pyxform makes available since it's likely to be up-to-date and tested. 

I have confimed that the change in this PR produces an XForm whose bindings match the bindings in pyxform. I could not confirm that the entire form is the same because the ordering of the rest of the form seems random.