### PR TITLE
Add missing binaries in dockerfile (for gunicorn)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 FROM python:3.12.5-alpine AS runtime
 WORKDIR /usr/src/app
 RUN apk --update --no-cache add openjdk8-jre-base
-COPY --from=build /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/
+COPY --from=build /usr/local/bin /usr/local/bin
+COPY --from=build /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 COPY . .
 EXPOSE 8000
 VOLUME ["/tmp_home", "/persistent_home"]


### PR DESCRIPTION
I realised in https://github.com/getodk/xlsform-online/commit/e5a39f7cbc219635137768251e83869cda9cfa4a that I missed copying the locally installed binaries.

This means that `gunicorn` was not available in the path, and the container could not start up.

This PR:
- Adds the bins to the final image stage, making `gunicorn` command available.
- I also correctly added the python libs under `site-packages`, where they should be by default 👍 